### PR TITLE
:bookmark: 2025.02.06

### DIFF
--- a/src/Module_2_Data_Structures/Labs_6_to_9/Lab_6/Program_3.py
+++ b/src/Module_2_Data_Structures/Labs_6_to_9/Lab_6/Program_3.py
@@ -9,12 +9,13 @@ def main():
     user_queue.register(User(name="Carlos-Rodriguez", id=67890234))
     user_queue.register(User(name="Mariana-Lopez", id=56789012))
     user_queue.register(User(name="Andres-Valencia", id=34567891))
+    user_queue.save_to_file()
 
-    print(user_queue)
+    input("Presiona Enter para continuar...")
+
     user_queue.serve_next()
     user_queue.serve_next()
     user_queue.save_to_file()
-    print(user_queue)
 
 if __name__ == "__main__":
     main()

--- a/src/Module_2_Data_Structures/Labs_6_to_9/Lab_6/Stack.py
+++ b/src/Module_2_Data_Structures/Labs_6_to_9/Lab_6/Stack.py
@@ -22,7 +22,7 @@ class Stack(Generic[T]):
         return self.items.is_empty()
 
     def push(self, data: T):
-        self.items.push_back()
+        self.items.push_back(data)
 
     def pop(self) -> T:
         return self.items.pop_back()


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed the `push` method to correctly pass data to `push_back`.

- Added a user input pause to enhance script flow.

- Updated `Program_3.py` to include a pause and remove redundant prints.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Program_3.py</strong><dd><code>Enhanced script flow with user input pause</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Module_2_Data_Structures/Labs_6_to_9/Lab_6/Program_3.py

<li>Added a user input pause for better flow.<br> <li> Removed redundant print statements.<br> <li> Ensured <code>save_to_file</code> is called after user registration.


</details>


  </td>
  <td><a href="https://github.com/Cxx-mlr/DS-UNAL-2024-2/pull/51/files#diff-7a7e8b22b3f92349b5504015350e772119d16118a0cd8dbe0b2725371c088980">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Stack.py</strong><dd><code>Fixed `push` method to correctly pass data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Module_2_Data_Structures/Labs_6_to_9/Lab_6/Stack.py

- Fixed `push` method to pass data to `push_back`.


</details>


  </td>
  <td><a href="https://github.com/Cxx-mlr/DS-UNAL-2024-2/pull/51/files#diff-d97529f2d7ef456a180762b35a202e33e24f9e751509f8b0f94a9971af43d7dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>